### PR TITLE
Refactor JWT::deserialise()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 ## Unreleased
 
 - Added: Support for AES GCM family of algorithms
+- Changed: SimpleJWT\JWT::decode() no longer supports $format parameter
+  (format is automatically detected)
+- Changed: SimpleJWT\JWT::deserialise() no longer supports $format parameter
+  (format is automatically detected)
+- Changed: Return value of SimpleJWT\JWT::deserialise() changed
 - Removed: SimpleJWT\Keys\Key::getSignature()
 
 ## Version 0.4.2

--- a/README.md
+++ b/README.md
@@ -131,16 +131,17 @@ You can also deserialise a JWT without verifying it using the deserialise functi
 
 ```php
 try {
-    list($headers, $claims, $signing_input, $signature) =
-        SimpleJWT\JWT::deserialise('abc.def.ghigjghr');
+    $result = SimpleJWT\JWT::deserialise('abc.def.ghigjghr');
 } catch (SimpleJWT\InvalidTokenException $e) {
 
 }
 
-print $header['alg'];
-print $header['sub'];
-print $signing_input;  // abc.def
-print $signature;      // ghigjghr
+print $result['claims']['sub'];
+print $result['signatures'][0]['headers']['alg'];
+print $result['signatures'][0]['signing_input'];  // abc.def
+print $result['signatures'][0]['signature'];      // ghigjghr
+// Additional indices under $result['signatures'] if the JWT has more than
+// one signature
 ```
 
 ### Creating a JWE

--- a/src/SimpleJWT/JWT.php
+++ b/src/SimpleJWT/JWT.php
@@ -258,9 +258,10 @@ class JWT {
      *
      * @param string $token the serialised JWT
      * @param string $format the JWT serialisation format
-     * @return array an array containing the deserialised header,
-     * deserialised claims, the signing input (i.e. the first two
-     * parts of the serialised JWT) and signature
+     * @return array an array containing `claims` (deserialised claims) and
+     * `signatures`, an array of arrays each containing `headers` (the
+     * deserialised header), `signing_input` (i.e. the first two
+     * parts of the serialised JWT) and `signature` (the signature)
      * @throws InvalidTokenException if the token is invalid for any reason
      */
     public static function deserialise($token) {

--- a/tests/JWTTest.php
+++ b/tests/JWTTest.php
@@ -127,22 +127,22 @@ class JWTTest extends TestCase {
 
     function testDeserialiseCompact() {
         $token = 'eyJ0eXAiOiJKV1QiLA0KICJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJqb2UiLA0KICJleHAiOjEzMDA4MTkzODAsDQogImh0dHA6Ly9leGFtcGxlLmNvbS9pc19yb290Ijp0cnVlfQ.dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk';
-        list($headers, $claims, $signing_input, $signature) = JWT::deserialise($token);
+        $result = JWT::deserialise($token);
 
-        $this->assertEquals('HS256', $headers['alg']);
-        $this->assertTrue($claims['http://example.com/is_root']);
-        $this->assertEquals('eyJ0eXAiOiJKV1QiLA0KICJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJqb2UiLA0KICJleHAiOjEzMDA4MTkzODAsDQogImh0dHA6Ly9leGFtcGxlLmNvbS9pc19yb290Ijp0cnVlfQ', $signing_input);
-        $this->assertEquals('dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk', $signature);
+        $this->assertEquals('HS256', $result['signatures'][0]['headers']['alg']);
+        $this->assertTrue($result['claims']['http://example.com/is_root']);
+        $this->assertEquals('eyJ0eXAiOiJKV1QiLA0KICJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJqb2UiLA0KICJleHAiOjEzMDA4MTkzODAsDQogImh0dHA6Ly9leGFtcGxlLmNvbS9pc19yb290Ijp0cnVlfQ', $result['signatures'][0]['signing_input']);
+        $this->assertEquals('dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk', $result['signatures'][0]['signature']);
     }
 
     function testDeserialiseJSON() {
         $token = '{"payload":"eyJpc3MiOiJqb2UiLA0KICJleHAiOjEzMDA4MTkzODAsDQogImh0dHA6Ly9leGFtcGxlLmNvbS9pc19yb290Ijp0cnVlfQ","signatures":[{"protected":"eyJ0eXAiOiJKV1QiLA0KICJhbGciOiJIUzI1NiJ9","signature":"dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk"}]}';
-        list($headers, $claims, $signing_input, $signature) = JWT::deserialise($token, JWT::JSON_FORMAT);
+        $result = JWT::deserialise($token, JWT::JSON_FORMAT);
 
-        $this->assertEquals('HS256', $headers['alg']);
-        $this->assertTrue($claims['http://example.com/is_root']);
-        $this->assertEquals('eyJ0eXAiOiJKV1QiLA0KICJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJqb2UiLA0KICJleHAiOjEzMDA4MTkzODAsDQogImh0dHA6Ly9leGFtcGxlLmNvbS9pc19yb290Ijp0cnVlfQ', $signing_input);
-        $this->assertEquals('dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk', $signature);
+        $this->assertEquals('HS256', $result['signatures'][0]['headers']['alg']);
+        $this->assertTrue($result['claims']['http://example.com/is_root']);
+        $this->assertEquals('eyJ0eXAiOiJKV1QiLA0KICJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJqb2UiLA0KICJleHAiOjEzMDA4MTkzODAsDQogImh0dHA6Ly9leGFtcGxlLmNvbS9pc19yb290Ijp0cnVlfQ', $result['signatures'][0]['signing_input']);
+        $this->assertEquals('dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk', $result['signatures'][0]['signature']);
     }
 
     function testVerifyHMAC() {


### PR DESCRIPTION
The original API for JWT::deserialise() does not contemplate situations whereby a JWT has multiple signatures (which is allowed in certain representations under [RFC 7515][1].  The return value of this function is restructured so that multiple signatures can be returned.

This API fix will fully resolve #29.

[1]: https://tools.ietf.org/html/rfc7515#section-7.2.1