### PR TITLE
Fix for PHP 8.1 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+- Fixed: Compatibility with PHP 8.1 when using ECDH (#58)
+
 ## 0.6.1
 
 - Changed: JWT::deserialise() no longer takes a `$format` parameter (which

--- a/src/SimpleJWT/Keys/KeyFactory.php
+++ b/src/SimpleJWT/Keys/KeyFactory.php
@@ -64,7 +64,7 @@ class KeyFactory {
     /** @var array<string, string> $pem_map */
     static $pem_map = [
         RSAKey::PEM_PRIVATE => 'SimpleJWT\Keys\RSAKey',
-        ECKey::PEM_PRIVATE => 'SimpleJWT\Keys\ECKey'
+        ECKey::PEM_RFC5915_PRIVATE => 'SimpleJWT\Keys\ECKey'
     ];
 
     /** @var array<string, string> $oid_map */

--- a/src/SimpleJWT/Keys/KeyFactory.php
+++ b/src/SimpleJWT/Keys/KeyFactory.php
@@ -166,6 +166,9 @@ class KeyFactory {
                         return new $cls($data, 'pem');
                     }
                 }
+
+                // TODO - it's probably PKCS#8, which uses BEGIN PRIVATE KEY
+                throw new KeyException('PEM key format not supported');
             }
         }
 


### PR DESCRIPTION
In PHP 8.1, openssl_pkey_export() for EC keys uses a PKCS#8 wrapper instead of just a RFC 5915 private key. ECKey has to be updated to accept this new format.

Fixes #58 