### PR TITLE
Throw KeyException on malformed JSON

### DIFF
--- a/src/SimpleJWT/Keys/Key.php
+++ b/src/SimpleJWT/Keys/Key.php
@@ -74,6 +74,8 @@ abstract class Key implements KeyInterface {
                 if (!is_string($data)) throw new KeyException('Incorrect key data format - string expected');
                 $jwk = json_decode($data, true);
 
+                if(null === $jwk) throw new KeyException('Incorrect key data format - malformed JSON');
+
                 if (isset($jwk['ciphertext'])) {
                     $this->data = self::decrypt($data, $password, $alg);
                 } else {

--- a/src/SimpleJWT/Keys/Key.php
+++ b/src/SimpleJWT/Keys/Key.php
@@ -74,7 +74,7 @@ abstract class Key implements KeyInterface {
                 if (!is_string($data)) throw new KeyException('Incorrect key data format - string expected');
                 $jwk = json_decode($data, true);
 
-                if(null === $jwk) throw new KeyException('Incorrect key data format - malformed JSON');
+                if ((null === $jwk) && ($json_err = json_last_error_msg())) throw new KeyException('Incorrect key data format - malformed JSON: ' . $json_err);
 
                 if (isset($jwk['ciphertext'])) {
                     $this->data = self::decrypt($data, $password, $alg);


### PR DESCRIPTION
Throw a KeyException if a malformed JSON has been provided for a JSON web key

Currently, if a malformed JSON is provided, you get a bunch of warnings and an empty `Key` object:
```php
Warning:  Trying to access array offset on value of type null in /vendor/kelvinmo/simplejwt/src/SimpleJWT/Keys/Key.php on line 290
Warning:  Trying to access array offset on value of type null in /vendor/kelvinmo/simplejwt/src/SimpleJWT/Keys/Key.php on line 290
Warning:  Trying to access array offset on value of type null in /vendor/kelvinmo/simplejwt/src/SimpleJWT/Keys/Key.php on line 290
Warning:  Trying to access array offset on value of type null in /vendor/kelvinmo/simplejwt/src/SimpleJWT/Keys/Key.php on line 290

object(SimpleJWT\Keys\ECKey)#6 (1) {
  ["data":protected]=>
  array(2) {
    ["kid"]=>
    string(7) "euxjU4G"
    ["kty"]=>
    string(2) "EC"
  }
}
```

This pull request resolves this issue.