### PR TITLE
Disable automatic key ID generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ All notable changes to this project will be documented in this file.
 - Changed: Refactored `Algorithm` (now renamed to `BaseAlgorithm`)
   and `Key` to extract interfaces (into `AlgorithmInterface` and 
   `KeyInterface` respectively)
+- Changed: Key ID `kid` parameter no longer automatically generated
+  when a Key object is created.  Use `Key::getKeyId(true)` or
+  `KeySet::add(..., true)` to generate a key ID
 - Removed: Helper::getObject() and Helper::getJWTObject() have been
   replaced by Helper::decode() and Helper::decodeFully() respectively
 - Removed: Support for PHP 7.1

--- a/src/SimpleJWT/Keys/ECKey.php
+++ b/src/SimpleJWT/Keys/ECKey.php
@@ -282,13 +282,14 @@ class ECKey extends Key implements ECDHKeyInterface, PEMInterface {
     }
 
     public function getPublicKey() {
-        return new ECKey([
-            'kid' => $this->data['kid'],
+        $data = [
             'kty' => $this->data['kty'],
             'crv' => $this->data['crv'],
             'x' => $this->data['x'],
             'y' => $this->data['y']
-        ], 'php');
+        ];
+        if (isset($this->data['kid'])) $data['kid'] = $this->data['kid'];
+        return new ECKey($data, 'php');
     }
 
     public function toPEM() {

--- a/src/SimpleJWT/Keys/Key.php
+++ b/src/SimpleJWT/Keys/Key.php
@@ -86,10 +86,6 @@ abstract class Key implements KeyInterface {
                 if (!is_string($data)) throw new KeyException('Incorrect key data format - string expected');
                 $this->data = self::decrypt($data, $password, $alg);
         }
-
-        if (!isset($this->data['kid'])) {
-            $this->data['kid'] = substr($this->getThumbnail(), 0, 7);
-        }
     }
 
     /**
@@ -117,8 +113,11 @@ abstract class Key implements KeyInterface {
     /**
      * {@inheritdoc}
      */
-    public function getKeyId() {
-        return $this->data['kid'];
+    public function getKeyId(bool $generate = false) {
+        if (!isset($this->data['kid']) && $generate) {
+            $this->data['kid'] = substr($this->getThumbnail(), 0, 7);
+        }
+        return isset($this->data['kid']) ? $this->data['kid'] : null;
     }
 
     /**

--- a/src/SimpleJWT/Keys/KeyInterface.php
+++ b/src/SimpleJWT/Keys/KeyInterface.php
@@ -45,9 +45,11 @@ interface KeyInterface {
     /**
      * Returns the key ID
      *
-     * @return string the key ID
+     * @param bool $generate whether to generate the key ID if it is not
+     * present
+     * @return string|null the key ID
      */
-    public function getKeyId();
+    public function getKeyId(bool $generate = false);
 
     /**
      * Returns the type of the key

--- a/src/SimpleJWT/Keys/KeySet.php
+++ b/src/SimpleJWT/Keys/KeySet.php
@@ -111,14 +111,18 @@ class KeySet {
      * key contents) already exists in the key set.
      *
      * @param KeyInterface $key the key to add
+     * @param bool $generate whether to generate a key ID for the key being
+     * added, if it is not present
      * @return void
      * @throws KeyException if there is an identical key
      */
-    function add($key) {
+    function add($key, $generate = false) {
         $thumbnail = $key->getThumbnail();
+        $kid = $key->getKeyId($generate);
+
         foreach ($this->keys as $existing_key) {
             if ($existing_key->getThumbnail() == $thumbnail) throw new KeyException('Key already exists');
-            if ($existing_key->getKeyId() == $key->getKeyId()) throw new KeyException('Key already exists');
+            if (($kid != null) && ($existing_key->getKeyId(true) == $kid)) throw new KeyException('Key already exists');
         }
 
         $this->keys[] = $key;

--- a/src/SimpleJWT/Keys/OKPKey.php
+++ b/src/SimpleJWT/Keys/OKPKey.php
@@ -89,12 +89,13 @@ class OKPKey extends Key implements ECDHKeyInterface {
     }
 
     public function getPublicKey() {
-        return new OKPKey([
-            'kid' => $this->data['kid'],
+        $data = [
             'kty' => $this->data['kty'],
             'crv' => $this->data['crv'],
             'x' => $this->data['x']
-        ], 'php');
+        ];
+        if (isset($this->data['kid'])) $data['kid'] = $this->data['kid'];
+        return new OKPKey($data, 'php');
     }
 
     /**

--- a/src/SimpleJWT/Keys/RSAKey.php
+++ b/src/SimpleJWT/Keys/RSAKey.php
@@ -133,12 +133,13 @@ class RSAKey extends Key implements PEMInterface {
     }
 
     public function getPublicKey() {
-        return new RSAKey([
-            'kid' => $this->data['kid'],
+        $data = [
             'kty' => $this->data['kty'],
             'n' => $this->data['n'],
             'e' => $this->data['e']
-        ], 'php');
+        ];
+        if (isset($this->data['kid'])) $data['kid'] = $this->data['kid'];
+        return new RSAKey($data, 'php');
     }
 
     public function toPEM() {

--- a/tests/KeyManagement/ECDHTest.php
+++ b/tests/KeyManagement/ECDHTest.php
@@ -23,7 +23,6 @@ class ECKeyMock extends ECKey {
 
     public function getPublicKey() {
         return new ECKeyMock([
-            'kid' => $this->data['kid'],
             'kty' => $this->data['kty'],
             'crv' => $this->data['crv'],
             'x' => $this->data['x'],


### PR DESCRIPTION
Currently, when a `Key` object is created and the `kid` (key ID) parameter is missing, the key ID is automatically generated using the key's thumbnail.

This is undesirable behaviour as it changes the underlying key data without explicit instruction from the user.