### PR TITLE
Throw KeyException when loading an invalid PEM RSAKey

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+- Fixed: Throw a `KeyException` when loading an invalid PEM-encoded
+  RSAKey
+
 ## 0.8.0
 
 - Added: Support for `Ed25519` signatures and `X25519` key derviation

--- a/src/SimpleJWT/Keys/RSAKey.php
+++ b/src/SimpleJWT/Keys/RSAKey.php
@@ -119,6 +119,8 @@ class RSAKey extends Key implements PEMInterface {
                     $jwk['dp'] = Util::base64url_encode($seq->getChildAt(6)->getValueAsUIntOctets());
                     $jwk['dq'] = Util::base64url_encode($seq->getChildAt(7)->getValueAsUIntOctets());
                     $jwk['qi'] = Util::base64url_encode($seq->getChildAt(8)->getValueAsUIntOctets());
+                } else {
+                    throw new KeyException('Unrecognised key format');
                 }
 
                 parent::__construct($jwk);


### PR DESCRIPTION
### Description

Add code to `RSAKey::__construct()` to throw KeyException when loading an invalid PEM formatted string (i.e. a string that doesn't contain BEGIN PUBLIC KEY or BEGIN RSA PRIVATE KEY)

Fixes #173

## Types of changes

*Put an `x` in the boxes that apply*

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality
      to not work as expected)
- [ ] This change requires an update to the documentation

## Checklist

*Put an `x` in the boxes that apply. You can also update these after submitting
the pull request.*

- [x] My code is consistent with the styles used in this project
- [x] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature
      works
- [ ] New and existing unit tests and static analysis pass locally with my
      changes
- [ ] I have updated the user documentation (if appropriate)

## Further comments

