### PR TITLE
Add type checking when creating algorithm classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ All notable changes to this project will be documented in this file.
 - Changed: Providing invalid JSON tokens into JWT::deserialise() and
   JWE::decrypt() will throw an `InvalidTokenException` instead of
   `InvalidArgumentException`
+- Changed: `JWT` and `JWE` methods now check for validity of
+  algorithm classes
 - Removed: Support for PHP 7.2
 
 ## 0.8.1

--- a/src/SimpleJWT/JWE.php
+++ b/src/SimpleJWT/JWE.php
@@ -37,6 +37,8 @@ namespace SimpleJWT;
 use \JsonException;
 use SimpleJWT\Crypt\AlgorithmFactory;
 use SimpleJWT\Crypt\CryptException;
+use SimpleJWT\Crypt\Encryption\EncryptionAlgorithm;
+use SimpleJWT\Crypt\KeyManagement\KeyManagementAlgorithm;
 use SimpleJWT\Crypt\KeyManagement\KeyDerivationAlgorithm;
 use SimpleJWT\Crypt\KeyManagement\KeyEncryptionAlgorithm;
 use SimpleJWT\Keys\KeySet;
@@ -141,9 +143,13 @@ class JWE extends Token {
 
         if ($headers['alg'] != $expected_alg) throw new InvalidTokenException('Unexpected algorithm', InvalidTokenException::DECRYPTION_ERROR);
         $key_enc = AlgorithmFactory::create($headers['alg']);
+        if (!($key_enc instanceof KeyManagementAlgorithm))
+            throw new InvalidTokenException('Invalid key algorithm: ' . $headers['alg'], InvalidTokenException::DECRYPTION_ERROR);
 
-        /** @var \SimpleJWT\Crypt\Encryption\EncryptionAlgorithm $content_enc */
+        /** @var EncryptionAlgorithm $content_enc */
         $content_enc = AlgorithmFactory::create($headers['enc']);
+        if (!($content_enc instanceof EncryptionAlgorithm))
+            throw new InvalidTokenException('Invalid content encryption algorithm: ' . $headers['enc'], InvalidTokenException::DECRYPTION_ERROR);
 
         $key_decryption_keys = $keys;
 
@@ -239,9 +245,13 @@ class JWE extends Token {
         if (!isset($this->headers['enc'])) throw new \InvalidArgumentException('enc parameter missing');
 
         $key_enc = AlgorithmFactory::create($this->headers['alg']);
+        if (!($key_enc instanceof KeyManagementAlgorithm))
+            throw new \InvalidArgumentException('Invalid key algorithm: ' . $this->headers['alg']);
         
-        /** @var \SimpleJWT\Crypt\Encryption\EncryptionAlgorithm $content_enc */
+        /** @var EncryptionAlgorithm $content_enc */
         $content_enc = AlgorithmFactory::create($this->headers['enc']);
+        if (!($content_enc instanceof EncryptionAlgorithm))
+            throw new \InvalidArgumentException('Invalid content encryption algorithm: ' . $this->headers['enc']);
 
         $key_encryption_keys = $keys;
 


### PR DESCRIPTION
SimpleJWT uses `AlgorithmFactory::create()` to create algorithm classes (signature algorithms, key management algorithms and content encryption algorithms) based on `alg` and/or `enc` parameters.  However, the types of these classes are not checked.  Therefore it is possible to specify a key management algorithm when a signature algorithm is expected, leading to errors further down the line.

The PR adds the appropriate type checking code.