### PR TITLE
Use gmp operator overload instead of gmp_pow for certain PHP versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ jobs:
           - 8.0
           - 8.1
           - 8.2
+          - 8.3
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/src/SimpleJWT/Util/BigNum.php
+++ b/src/SimpleJWT/Util/BigNum.php
@@ -217,6 +217,9 @@ class BigNum {
     function _pow($base, $exp) {
         if (is_object($exp) && ($exp instanceof \GMP))
             $exp = gmp_intval($exp);
+        /** @disregard P1006  */
+        if (version_compare(PHP_VERSION, '8.2.26', '==') || version_compare(PHP_VERSION, '8.3.14', '=='))
+            return ($base ** $exp);
         return gmp_pow($base, $exp);
     }
 


### PR DESCRIPTION
There is a bug in PHP 8.3.14 and 8.2.26 that causes `gmp_pow` to fail.
See https://github.com/php/php-src/issues/16870

Using operator overloading (`**`) instead of `gmp_pow` may fix the issue.
See https://github.com/php/php-src/issues/16870#issuecomment-2499293925

Fixes #214 