### PR TITLE
Add error codes to exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+- Added: Error codes in BinaryEncodingException, CryptException and
+  KeyException to provide more useful error diagnosis
+
 ## [1.0.1]
 
 - Fixed: Uncaught `SodiumException` if an error occurs in functions
@@ -231,6 +236,7 @@ All notable changes to this project will be documented in this file.
 
 - Initial release
 
+[Unreleased]: https://github.com/kelvinmo/simplejwt/compare/v1.0.1...HEAD
 [1.0.1]: https://github.com/kelvinmo/simplejwt/compare/v0.1.0...v1.0.1
 [1.0.0]: https://github.com/kelvinmo/simplejwt/compare/v0.9.3...v1.0.0
 [0.9.3]: https://github.com/kelvinmo/simplejwt/compare/v0.9.2...v0.9.3

--- a/src/SimpleJWT/Crypt/CryptException.php
+++ b/src/SimpleJWT/Crypt/CryptException.php
@@ -39,7 +39,28 @@ namespace SimpleJWT\Crypt;
  * An exception associated with cryptographic processing.
  */
 class CryptException extends \RuntimeException {
-    
+    /**
+     * Error code indicating that the source data is invalid.
+     */
+    const INVALID_DATA_ERROR = 1;
+
+    /**
+     * Error code indicating that a key matching the required criteria
+     * cannot be found in the supplied keyset
+     */
+    const KEY_NOT_FOUND_ERROR = 3;
+
+    /**
+     * Error code indicating that an error occurred in an underlying
+     * system library (such as openssl or libsodium).
+     */
+    const SYSTEM_LIBRARY_ERROR = 4;
+
+    /**
+     * Error code indicating that the validation of a signature or
+     * authentication tag has failed.
+     */
+    const VALIDATION_FAILED_ERROR = 10;
 }
 
 ?>

--- a/src/SimpleJWT/Crypt/KeyManagement/AESGCMKeyWrap.php
+++ b/src/SimpleJWT/Crypt/KeyManagement/AESGCMKeyWrap.php
@@ -77,7 +77,7 @@ class AESGCMKeyWrap extends BaseAlgorithm implements KeyEncryptionAlgorithm {
         /** @var SymmetricKey $key */
         $key = $this->selectKey($keys, $kid);
         if ($key == null) {
-            throw new CryptException('Key not found or is invalid');
+            throw new CryptException('Key not found or is invalid', CryptException::KEY_NOT_FOUND_ERROR);
         }
 
         $iv = Util::base64url_encode($this->generateIV());
@@ -94,10 +94,10 @@ class AESGCMKeyWrap extends BaseAlgorithm implements KeyEncryptionAlgorithm {
         /** @var SymmetricKey $key */
         $key = $this->selectKey($keys, $kid);
         if ($key == null) {
-            throw new CryptException('Key not found or is invalid');
+            throw new CryptException('Key not found or is invalid', CryptException::KEY_NOT_FOUND_ERROR);
         }
         if (!isset($headers['iv']) || !isset($headers['tag'])) {
-            throw new CryptException('iv or tag headers not set');
+            throw new CryptException('iv or tag headers not set', CryptException::INVALID_DATA_ERROR);
         }
 
         $cek = $this->aesgcm->decryptAndVerify($encrypted_key, $headers['tag'], $key->toBinary(), '', $headers['iv']);

--- a/src/SimpleJWT/Crypt/KeyManagement/AESKeyWrap.php
+++ b/src/SimpleJWT/Crypt/KeyManagement/AESKeyWrap.php
@@ -101,10 +101,10 @@ class AESKeyWrap extends BaseAlgorithm implements KeyEncryptionAlgorithm {
         /** @var SymmetricKey $key */
         $key = $this->selectKey($keys, $kid);
         if ($key == null) {
-            throw new CryptException('Key not found or is invalid');
+            throw new CryptException('Key not found or is invalid', CryptException::KEY_NOT_FOUND_ERROR);
         }
 
-        if ((strlen($cek) % 8) != 0) throw new CryptException('Content encryption key not a multiple of 64 bits');
+        if ((strlen($cek) % 8) != 0) throw new CryptException('Content encryption key not a multiple of 64 bits', CryptException::INVALID_DATA_ERROR);
 
         $cipher = self::$alg_params[$this->getAlg()]['cipher'];
 
@@ -120,7 +120,7 @@ class AESKeyWrap extends BaseAlgorithm implements KeyEncryptionAlgorithm {
                 if ($B == false) {
                     $messages = [];
                     while ($message = openssl_error_string()) $messages[] = $message;
-                    throw new CryptException('Cannot encrypt key: ' . implode("\n", $messages));
+                    throw new CryptException('Cannot encrypt key: ' . implode("\n", $messages), CryptException::SYSTEM_LIBRARY_ERROR);
                 }
 
                 $A = $this->msb($B) ^ Util::packInt64($t);
@@ -138,7 +138,7 @@ class AESKeyWrap extends BaseAlgorithm implements KeyEncryptionAlgorithm {
         /** @var SymmetricKey $key */
         $key = $this->selectKey($keys, $kid);
         if ($key == null) {
-            throw new CryptException('Key not found or is invalid');
+            throw new CryptException('Key not found or is invalid', CryptException::KEY_NOT_FOUND_ERROR);
         }
 
         $cipher = self::$alg_params[$this->getAlg()]['cipher'];
@@ -154,7 +154,7 @@ class AESKeyWrap extends BaseAlgorithm implements KeyEncryptionAlgorithm {
                 if ($B == false) {
                     $messages = [];
                     while ($message = openssl_error_string()) $messages[] = $message;
-                    throw new CryptException('Cannot decrypt key: ' . implode("\n", $messages));
+                    throw new CryptException('Cannot decrypt key: ' . implode("\n", $messages), CryptException::SYSTEM_LIBRARY_ERROR);
                 }
                 $A = $this->msb($B);
                 $R[$i] = $this->lsb($B);
@@ -162,7 +162,7 @@ class AESKeyWrap extends BaseAlgorithm implements KeyEncryptionAlgorithm {
         }
 
         if (!Util::secure_compare($A, self::RFC3394_IV)) {
-            throw new CryptException('AES key wrap integrity check failed');
+            throw new CryptException('AES key wrap integrity check failed', CryptException::VALIDATION_FAILED_ERROR);
         }
 
         return implode('', $R);

--- a/src/SimpleJWT/Crypt/KeyManagement/DirectEncryption.php
+++ b/src/SimpleJWT/Crypt/KeyManagement/DirectEncryption.php
@@ -66,7 +66,7 @@ class DirectEncryption extends BaseAlgorithm implements KeyDerivationAlgorithm {
         /** @var SymmetricKey $key */
         $key = $this->selectKey($keys, $kid);
         if ($key == null) {
-            throw new CryptException('Key not found or is invalid');
+            throw new CryptException('Key not found or is invalid', CryptException::KEY_NOT_FOUND_ERROR);
         }
         $headers['kid'] = $key->getKeyId();
 

--- a/src/SimpleJWT/Crypt/KeyManagement/ECDH_AESKeyWrap.php
+++ b/src/SimpleJWT/Crypt/KeyManagement/ECDH_AESKeyWrap.php
@@ -100,7 +100,7 @@ class ECDH_AESKeyWrap extends ECDH implements KeyEncryptionAlgorithm {
 
         $wrapping_key = $this->selectKey($keys, $criteria);
         if (($wrapping_key == null) || !($wrapping_key instanceof SymmetricKey)) {
-            throw new CryptException('Wrapping key not found');
+            throw new CryptException('Wrapping key not found', CryptException::KEY_NOT_FOUND_ERROR);
         }
 
         return $this->wrapKey($cek, $wrapping_key->toBinary(), $headers);
@@ -115,7 +115,7 @@ class ECDH_AESKeyWrap extends ECDH implements KeyEncryptionAlgorithm {
 
         $wrapping_key = $this->selectKey($keys, $criteria);
         if (($wrapping_key == null) || !($wrapping_key instanceof SymmetricKey)) {
-            throw new CryptException('Wrapping key not found');
+            throw new CryptException('Wrapping key not found', CryptException::KEY_NOT_FOUND_ERROR);
         }
 
         return $this->unwrapKey($encrypted_key, $wrapping_key->toBinary(), $headers);

--- a/src/SimpleJWT/Crypt/KeyManagement/PBES2.php
+++ b/src/SimpleJWT/Crypt/KeyManagement/PBES2.php
@@ -123,7 +123,7 @@ class PBES2 extends BaseAlgorithm implements KeyEncryptionAlgorithm {
         /** @var SymmetricKey $key */
         $key = $this->selectKey($keys, $kid);
         if ($key == null) {
-            throw new CryptException('Key not found or is invalid');
+            throw new CryptException('Key not found or is invalid', CryptException::KEY_NOT_FOUND_ERROR);
         }
 
         $derived_key = $this->generateKeyFromPassword($key->toBinary(), $headers);
@@ -137,10 +137,10 @@ class PBES2 extends BaseAlgorithm implements KeyEncryptionAlgorithm {
         /** @var SymmetricKey $key */
         $key = $this->selectKey($keys, $kid);
         if ($key == null) {
-            throw new CryptException('Key not found or is invalid');
+            throw new CryptException('Key not found or is invalid', CryptException::KEY_NOT_FOUND_ERROR);
         }
         if (!isset($headers['p2s']) || !isset($headers['p2c'])) {
-            throw new CryptException('p2s or p2c headers not set');
+            throw new CryptException('p2s or p2c headers not set', CryptException::INVALID_DATA_ERROR);
         }
 
         $derived_key = $this->generateKeyFromPassword($key->toBinary(), $headers);

--- a/src/SimpleJWT/Crypt/Signature/EdDSA.php
+++ b/src/SimpleJWT/Crypt/Signature/EdDSA.php
@@ -67,7 +67,7 @@ class EdDSA extends BaseAlgorithm implements SignatureAlgorithm {
     public function sign(string $data, KeySet $keys, ?string $kid = null): string {
         $key = $this->getSigningKey($keys, $kid);
         if (($key == null) || !($key instanceof OKPKey)) {
-            throw new KeyException('Key not found or is invalid');
+            throw new KeyException('Key not found or is invalid', KeyException::KEY_NOT_FOUND_ERROR);
         }
         /** @var non-empty-string $key_pair */
         $key_pair = $key->toSodium();
@@ -80,7 +80,7 @@ class EdDSA extends BaseAlgorithm implements SignatureAlgorithm {
     public function verify(string $signature, string $data, KeySet $keys, ?string $kid = null): bool {
         $key = $this->selectKey($keys, $kid, [KeyInterface::PUBLIC_PROPERTY => true, '~use' => 'sig']);
         if (($key == null) || !($key instanceof OKPKey)) {
-            throw new KeyException('Key not found or is invalid');
+            throw new KeyException('Key not found or is invalid', KeyException::KEY_NOT_FOUND_ERROR);
         }
 
         /** @var non-empty-string $binary */

--- a/src/SimpleJWT/Crypt/Signature/EdDSA.php
+++ b/src/SimpleJWT/Crypt/Signature/EdDSA.php
@@ -80,7 +80,7 @@ class EdDSA extends BaseAlgorithm implements SignatureAlgorithm {
             $binary = sodium_crypto_sign_detached($data, $secret_key);
             return Util::base64url_encode($binary);
         } catch (SodiumException $e) {
-            throw new CryptException('Cannot calculate signature: ' . $e->getMessage(), 0, $e);
+            throw new CryptException('Cannot calculate signature: ' . $e->getMessage(), CryptException::SYSTEM_LIBRARY_ERROR, $e);
         }
     }
 
@@ -98,7 +98,7 @@ class EdDSA extends BaseAlgorithm implements SignatureAlgorithm {
         try {
             return sodium_crypto_sign_verify_detached($binary, $data, $public_key);
         } catch (SodiumException $e) {
-            throw new CryptException('Cannot verify signature: ' . $e->getMessage(), 0, $e);
+            throw new CryptException('Cannot verify signature: ' . $e->getMessage(), CryptException::SYSTEM_LIBRARY_ERROR, $e);
         }
     }
 

--- a/src/SimpleJWT/Crypt/Signature/HMAC.php
+++ b/src/SimpleJWT/Crypt/Signature/HMAC.php
@@ -73,7 +73,7 @@ class HMAC extends SHA2 {
     public function sign(string $data, KeySet $keys, ?string $kid = null): string {
         $key = $this->getSigningKey($keys, $kid);
         if (($key == null) || !is_a($key, 'SimpleJWT\Keys\SymmetricKey')) {
-            throw new KeyException('Key not found or is invalid');
+            throw new KeyException('Key not found or is invalid', KeyException::KEY_NOT_FOUND_ERROR);
         }
         return Util::base64url_encode(hash_hmac('sha' . $this->size, $data, $key->toBinary(), true));
     }

--- a/src/SimpleJWT/Crypt/Signature/OpenSSLSig.php
+++ b/src/SimpleJWT/Crypt/Signature/OpenSSLSig.php
@@ -108,7 +108,7 @@ class OpenSSLSig extends SHA2 {
         if (!openssl_sign($data, $binary, $key->toPEM(), 'SHA' . $this->size)) {
             $messages = [];
             while ($message = openssl_error_string()) $messages[] = $message;
-            throw new CryptException('Cannot calculate signature: ' . implode("\n", $messages));
+            throw new CryptException('Cannot calculate signature: ' . implode("\n", $messages), CryptException::SYSTEM_LIBRARY_ERROR);
         }
 
         if ($key->getKeyType() == \SimpleJWT\Keys\ECKey::KTY) {
@@ -157,7 +157,7 @@ class OpenSSLSig extends SHA2 {
             default:
                 $messages = [];
                 while ($message = openssl_error_string()) $messages[] = $message;
-                throw new CryptException('Cannot verify signature: ' . implode("\n", $messages));
+                throw new CryptException('Cannot verify signature: ' . implode("\n", $messages), CryptException::SYSTEM_LIBRARY_ERROR);
         }
     }
 

--- a/src/SimpleJWT/Crypt/Signature/OpenSSLSig.php
+++ b/src/SimpleJWT/Crypt/Signature/OpenSSLSig.php
@@ -101,7 +101,7 @@ class OpenSSLSig extends SHA2 {
     public function sign(string $data, KeySet $keys, ?string $kid = null): string {
         $key = $this->getSigningKey($keys, $kid);
         if (($key == null) || !($key instanceof PEMInterface)) {
-            throw new KeyException('Key not found or is invalid');
+            throw new KeyException('Key not found or is invalid', KeyException::KEY_NOT_FOUND_ERROR);
         }
 
         $binary = '';
@@ -131,7 +131,7 @@ class OpenSSLSig extends SHA2 {
     public function verify(string $signature, string $data, KeySet $keys, ?string $kid = null): bool {
         $key = $this->selectKey($keys, $kid, [KeyInterface::PUBLIC_PROPERTY => true, '~use' => 'sig']);
         if (($key == null) || !($key instanceof PEMInterface)) {
-            throw new KeyException('Key not found or is invalid');
+            throw new KeyException('Key not found or is invalid', KeyException::KEY_NOT_FOUND_ERROR);
         }
 
         $binary = Util::base64url_decode($signature);

--- a/src/SimpleJWT/Keys/KeyException.php
+++ b/src/SimpleJWT/Keys/KeyException.php
@@ -39,7 +39,41 @@ namespace SimpleJWT\Keys;
  * An exception associated with processing JSON web keys.
  */
 class KeyException extends \RuntimeException {
+    /**
+     * Error code indicating that the source data is invalid.
+     */
+    const INVALID_KEY_ERROR = 1;
 
+    /**
+     * Error code indicating that a feature, while possibly compliant
+     * with the encoding specification, is not currently supported by the
+     * encoder.
+     */
+    const NOT_SUPPORTED_ERROR = 2;
+
+    /**
+     * Error code indicating that a key matching the required criteria
+     * cannot be found in the supplied keyset
+     */
+    const KEY_NOT_FOUND_ERROR = 3;
+
+    /**
+     * Error code indicating that an error occurred in an underlying
+     * system library (such as openssl or libsodium).
+     */
+    const SYSTEM_LIBRARY_ERROR = 4;
+
+    /**
+     * Error code indicating that the key is encrypted and cannot be
+     * decrypted.
+     */
+    const KEY_DECRYPTION_ERROR = 5;
+
+    /**
+     * Error code indicating that the specified key already exists
+     * in the key set.
+     */
+    const KEY_ALREADY_EXISTS_ERROR = 6;
 }
 
 ?>

--- a/src/SimpleJWT/Keys/KeySet.php
+++ b/src/SimpleJWT/Keys/KeySet.php
@@ -66,7 +66,7 @@ class KeySet {
                 $jwe = JWE::decrypt($jwk, $keys, $alg);
                 $jwk = $jwe->getPlaintext();
             } catch (CryptException $e) {
-                throw new KeyException('Cannot decrypt key set', 0, $e);
+                throw new KeyException('Cannot decrypt key set', KeyException::KEY_DECRYPTION_ERROR, $e);
             }
         }
 
@@ -76,7 +76,7 @@ class KeySet {
                 $this->keys[] = KeyFactory::create($key_data, 'php');
             }
         } catch (JsonException $e) {
-            throw new KeyException('Cannot decode key set JSON', 0, $e);
+            throw new KeyException('Cannot decode key set JSON', KeyException::INVALID_KEY_ERROR, $e);
         }
         
     }
@@ -127,8 +127,8 @@ class KeySet {
         $kid = $key->getKeyId($generate);
 
         foreach ($this->keys as $existing_key) {
-            if ($existing_key->getThumbnail() == $thumbnail) throw new KeyException('Key already exists');
-            if (($kid != null) && ($existing_key->getKeyId(true) == $kid)) throw new KeyException('Key already exists');
+            if ($existing_key->getThumbnail() == $thumbnail) throw new KeyException('Key already exists', KeyException::KEY_ALREADY_EXISTS_ERROR);
+            if (($kid != null) && ($existing_key->getKeyId(true) == $kid)) throw new KeyException('Key already exists', KeyException::KEY_ALREADY_EXISTS_ERROR);
         }
 
         $this->keys[] = $key;

--- a/src/SimpleJWT/Keys/OKPKey.php
+++ b/src/SimpleJWT/Keys/OKPKey.php
@@ -70,13 +70,13 @@ class OKPKey extends Key implements ECDHKeyInterface {
                 break;
             case 'cbor':
                 parent::__construct($data, $format, $password, $alg);
-                if ($this->data['kty'] != self::COSE_KTY) throw new KeyException('Incorrect CBOR key type');
+                if ($this->data['kty'] != self::COSE_KTY) throw new KeyException('Incorrect CBOR key type', KeyException::INVALID_KEY_ERROR);
                 $this->data['kty'] = self::KTY;
                 $this->replaceDataKeys([ -1 => 'crv', -2 => 'x', -4 => 'd' ]);
                 $this->replaceDataValues('crv', [ 4 => 'X25519', 6 => 'Ed25519' ]);
                 break;
             default:
-                throw new KeyException('Incorrect format');
+                throw new KeyException('Incorrect format', KeyException::INVALID_KEY_ERROR);
         }
     }
 
@@ -119,7 +119,7 @@ class OKPKey extends Key implements ECDHKeyInterface {
             $d = Util::base64url_decode($this->data['d']);
             $x = Util::base64url_decode($this->data['x']);
             if ((strlen($d) == 0) || strlen($x) == 0) {
-                throw new KeyException('Invalid key data');
+                throw new KeyException('Invalid key data', KeyException::INVALID_KEY_ERROR);
             }
             
             switch ($this->data['crv']) {
@@ -128,7 +128,7 @@ class OKPKey extends Key implements ECDHKeyInterface {
                 case 'X25519':
                     return sodium_crypto_box_keypair_from_secretkey_and_publickey($d, $x);
                 default:
-                    throw new KeyException('Cannot convert to Sodium format');
+                    throw new KeyException('Cannot convert to Sodium format', KeyException::INVALID_KEY_ERROR);
             }
         }
     }
@@ -168,14 +168,14 @@ class OKPKey extends Key implements ECDHKeyInterface {
     public function deriveAgreementKey(ECDHKeyInterface $public_key): string {
         assert(function_exists('sodium_crypto_scalarmult'));
 
-        if (!($public_key instanceof OKPKey)) throw new KeyException('Key type does not match');
-        if ($this->isPublic() || !$public_key->isPublic()) throw new KeyException('Parameter is not a public key');
+        if (!($public_key instanceof OKPKey)) throw new KeyException('Key type does not match', KeyException::INVALID_KEY_ERROR);
+        if ($this->isPublic() || !$public_key->isPublic()) throw new KeyException('Parameter is not a public key', KeyException::INVALID_KEY_ERROR);
 
         $public_key = Util::base64url_decode($public_key->data['x']);
         $secret_key = Util::base64url_decode($this->data['d']);
 
         $result = sodium_crypto_scalarmult($secret_key, $public_key);
-        if (strlen($result) != 32) throw new KeyException('Key agreement error');
+        if (strlen($result) != 32) throw new KeyException('Key agreement error', KeyException::SYSTEM_LIBRARY_ERROR);
         return $result;
     }
 

--- a/src/SimpleJWT/Keys/RSAKey.php
+++ b/src/SimpleJWT/Keys/RSAKey.php
@@ -211,7 +211,7 @@ class RSAKey extends Key implements PEMInterface {
      */
     protected static function parseASN1PrivateKey(ASN1Value $seq): array {
         $version = $seq->getChildAt(0)->getValue();
-        if ($version != 0) throw new KeyException('Unsupported RSA private key version', KeyException::UNSUPPORTED_ERROR);
+        if ($version != 0) throw new KeyException('Unsupported RSA private key version', KeyException::NOT_SUPPORTED_ERROR);
 
         return [
             'kty' => self::KTY,

--- a/src/SimpleJWT/Keys/SymmetricKey.php
+++ b/src/SimpleJWT/Keys/SymmetricKey.php
@@ -70,12 +70,12 @@ class SymmetricKey extends Key {
                 break;
             case 'cbor':
                 parent::__construct($data, $format, $password, $alg);
-                if ($this->data['kty'] != self::COSE_KTY) throw new KeyException('Incorrect CBOR key type');
+                if ($this->data['kty'] != self::COSE_KTY) throw new KeyException('Incorrect CBOR key type', KeyException::INVALID_KEY_ERROR);
                 $this->data['kty'] = self::KTY;
                 $this->replaceDataKeys([ -1 => 'k' ]);
                 break;
             case 'base64url':
-                if (!is_string($data)) throw new KeyException('Incorrect key data format - string expected');
+                if (!is_string($data)) throw new KeyException('Incorrect key data format - string expected', KeyException::INVALID_KEY_ERROR);
                 $jwk = [
                     'kty' => self::KTY,
                     'k' => $data
@@ -83,7 +83,7 @@ class SymmetricKey extends Key {
                 parent::__construct($jwk);
                 break;
             case 'base64':
-                if (!is_string($data)) throw new KeyException('Incorrect key data format - string expected');
+                if (!is_string($data)) throw new KeyException('Incorrect key data format - string expected', KeyException::INVALID_KEY_ERROR);
                 $jwk = [
                     'kty' => self::KTY,
                     'k' => trim(strtr($data, '+/', '-_'), '=')  // convert base64 to base64url
@@ -91,7 +91,7 @@ class SymmetricKey extends Key {
                 parent::__construct($jwk);
                 break;
             case 'bin':
-                if (!is_string($data)) throw new KeyException('Incorrect key data format - string expected');
+                if (!is_string($data)) throw new KeyException('Incorrect key data format - string expected', KeyException::INVALID_KEY_ERROR);
                 $jwk = [
                     'kty' => self::KTY,
                     'k' => Util::base64url_encode($data)
@@ -99,7 +99,7 @@ class SymmetricKey extends Key {
                 parent::__construct($jwk);
                 break;
             default:
-                throw new KeyException('Incorrect format');
+                throw new KeyException('Incorrect format', KeyException::INVALID_KEY_ERROR);
         }
 
         if (!isset($this->data['kty'])) $this->data['kty'] = self::KTY;

--- a/src/SimpleJWT/Util/BinaryEncodingException.php
+++ b/src/SimpleJWT/Util/BinaryEncodingException.php
@@ -40,7 +40,17 @@ namespace SimpleJWT\Util;
  * data.
  */
 class BinaryEncodingException extends \RuntimeException {
+    /**
+     * Error code indicating that the source data is invalid.
+     */
+    const INVALID_DATA_ERROR = 1;
 
+    /**
+     * Error code indicating that a feature, while possibly compliant
+     * with the encoding specification, is not currently supported by the
+     * encoder.
+     */
+    const NOT_SUPPORTED_ERROR = 2;
 }
 
 ?>

--- a/src/SimpleJWT/Util/CBOR/DataItem.php
+++ b/src/SimpleJWT/Util/CBOR/DataItem.php
@@ -275,7 +275,7 @@ class DataItem {
         } elseif (is_null($value)) {
             return static::null();
         } else {
-            throw new CBORException('Cannot represent as CBOR value');
+            throw new CBORException('Cannot represent as CBOR value', CBORException::NOT_SUPPORTED_ERROR);
         }
     }
 


### PR DESCRIPTION
Add error codes to `BinaryEncodingException`, `CryptException` and `KeyException` to provide more useful error diagnosis