### PR TITLE
Fix RSAKey::getSize()

### DIFF
--- a/src/SimpleJWT/Crypt/KeyManagement/RSAES.php
+++ b/src/SimpleJWT/Crypt/KeyManagement/RSAES.php
@@ -104,9 +104,7 @@ class RSAES extends BaseAlgorithm implements KeyEncryptionAlgorithm {
         $params = self::$alg_params[$this->getAlg()];
 
         if (isset($params['encoding']) && ($params['encoding'] == 'oaep')) {
-            // $key->getSize() ignores the first octet when calculating the key size,
-            // therefore we need to add it back in
-            $cek = $this->oaep_encode($cek, 1 + $key->getSize() / 8, $params['hash']);
+            $cek = $this->oaep_encode($cek, $key->getSize() / 8, $params['hash']);
         }
 
         $encrypted_key = '';
@@ -138,9 +136,7 @@ class RSAES extends BaseAlgorithm implements KeyEncryptionAlgorithm {
         }
 
         if (isset($params['encoding']) && ($params['encoding'] == 'oaep')) {
-            // $key->getSize() ignores the first octet when calculating the key size,
-            // therefore we need to add it back in
-            $cek = $this->oaep_decode($cek, 1 + $key->getSize() / 8, $params['hash']);
+            $cek = $this->oaep_decode($cek, $key->getSize() / 8, $params['hash']);
         }
 
         return $cek;

--- a/src/SimpleJWT/Keys/RSAKey.php
+++ b/src/SimpleJWT/Keys/RSAKey.php
@@ -139,8 +139,13 @@ class RSAKey extends Key implements PEMInterface {
     }
 
     public function getSize(): int {
-        // The modulus is a signed integer, therefore ignore the first byte
-        return 8 * (strlen(Util::base64url_decode($this->data['n'])) - 1);
+        $n = Util::base64url_decode($this->data['n']);
+        $length = strlen($n);
+        // $n may have a leading zero byte due to two's complements encoding - ignore
+        if ($n[0] == "\x00") {
+            $length -= 1;
+        }
+        return 8 * $length;
     }
 
     public function isPublic(): bool {


### PR DESCRIPTION
Refactor RSAKey::getSize() to detect leading zeros in two's complement encoding, and ignore when calculating the key size.

Fix #225.