### PR TITLE
add '?' to nullable method parameters

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ jobs:
           - 8.1
           - 8.2
           - 8.3
+          - 8.4
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.1
+          php-version: 8.4
           tools: composer
 
       - name: Get Composer cache directory

--- a/src/SimpleJWT/InvalidTokenException.php
+++ b/src/SimpleJWT/InvalidTokenException.php
@@ -87,7 +87,7 @@ class InvalidTokenException extends \RuntimeException {
      * @param int $time for TOO_EARLY_ERROR or TOO_LATE_ERROR, the required time specified
      * in the token
      */
-    public function __construct(string $message = "", int $code = 0, \Exception $previous = NULL, int $time = 0) {
+    public function __construct(string $message = "", int $code = 0, ?\Exception $previous = NULL, int $time = 0) {
         parent::__construct($message, $code, $previous);
         $this->time = $time;
     }

--- a/src/SimpleJWT/JWT.php
+++ b/src/SimpleJWT/JWT.php
@@ -96,7 +96,7 @@ class JWT extends Token {
      * @return JWT the decoded JWT
      * @throws InvalidTokenException if the token is invalid for any reason
      */
-    public static function decode(string $token, KeySet $keys, string $expected_alg, string $kid = null, $skip_validation = []) {
+    public static function decode(string $token, KeySet $keys, string $expected_alg, ?string $kid = null, $skip_validation = []) {
         if ($skip_validation === false) $skip_validation = [];
 
         $headers = [];
@@ -204,7 +204,7 @@ class JWT extends Token {
      * to sign the JWT
      * @throws \SimpleJWT\Crypt\CryptException if there is a cryptographic error
      */
-    public function encode(KeySet $keys, ?string $kid = null, $auto_complete = ['iat', 'kid'], string $alg = null, string $format = self::COMPACT_FORMAT): string {
+    public function encode(KeySet $keys, ?string $kid = null, $auto_complete = ['iat', 'kid'], ?string $alg = null, string $format = self::COMPACT_FORMAT): string {
         if ($auto_complete === false) $auto_complete = [];
         if ($alg != null) $this->headers['alg'] = $alg;
         if (in_array('iat', $auto_complete) && !isset($this->claims['iat'])) $this->claims['iat'] = time();

--- a/src/SimpleJWT/Keys/Key.php
+++ b/src/SimpleJWT/Keys/Key.php
@@ -234,7 +234,7 @@ abstract class Key implements KeyInterface {
      * @return string the JSON web key
      * @throws KeyException if the key cannot be converted
      */
-    public function toJWK(string $password = null, string $format = JWE::COMPACT_FORMAT): string {
+    public function toJWK(?string $password = null, string $format = JWE::COMPACT_FORMAT): string {
         $json = json_encode($this->data);
         if ($json == false) throw new KeyException('Cannot encode key', KeyException::INVALID_KEY_ERROR);
         if (($password == null) || $this->isPublic()) return $json;

--- a/src/SimpleJWT/Keys/KeyFactory.php
+++ b/src/SimpleJWT/Keys/KeyFactory.php
@@ -103,7 +103,7 @@ class KeyFactory {
      * @return KeyInterface the key object
      * @throws KeyException if an error occurs in reading the data
      */
-    static public function create($data, string $format = null, ?string $password = null, ?string $alg = 'PBES2-HS256+A128KW') {
+    static public function create($data, ?string $format = null, ?string $password = null, ?string $alg = 'PBES2-HS256+A128KW') {
         $cbor = new CBOR();
         $cbor_item = null;
 

--- a/src/SimpleJWT/Keys/KeySet.php
+++ b/src/SimpleJWT/Keys/KeySet.php
@@ -92,7 +92,7 @@ class KeySet {
      * @param string $format the serialisation format for the JWE
      * @return string the key set
      */
-    function toJWKS(string $password = null, string $format = JWE::COMPACT_FORMAT): string {
+    function toJWKS(?string $password = null, string $format = JWE::COMPACT_FORMAT): string {
         $result = array_map(function($key) {
             return $key->getKeyData();
         }, $this->keys);

--- a/src/SimpleJWT/Util/CBOR/DataItem.php
+++ b/src/SimpleJWT/Util/CBOR/DataItem.php
@@ -124,7 +124,7 @@ class DataItem {
      * @param mixed $value the native PHP value
      * @param int $tag the tag number (i.e. excluding the class and constructed bit masks)
      */
-    function __construct(int $type, $value, int $tag = null) {
+    function __construct(int $type, $value, ?int $tag = null) {
         $this->type = $type;
         $this->value = $value;
         $this->tag = $tag;


### PR DESCRIPTION
Issue: https://github.com/kelvinmo/simplejwt/issues/228

From PHP8.4, a parameter that has null as a default value has to be typed as a nullable type: https://www.php.net/manual/en/migration84.deprecated.php
This PR adds `?` to the method parameters that take `null` as a default value.