### PR TITLE
Change automatic `kid` generation to use full thumbnail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
-## [1.0.3]
+## [Unreleased]
 
 - Added: Error codes in BinaryEncodingException, CryptException and
   KeyException to provide more useful error diagnosis
+- Changed: Changed algorithm that automatically generate key IDs
+  (`kid`) to use full RFC7517 thumbnail
 
 ## [1.0.3]
 

--- a/src/SimpleJWT/Keys/Key.php
+++ b/src/SimpleJWT/Keys/Key.php
@@ -163,7 +163,7 @@ abstract class Key implements KeyInterface {
      */
     public function getKeyId(bool $generate = false): ?string {
         if (!isset($this->data['kid']) && $generate) {
-            $this->data['kid'] = substr($this->getThumbnail(), 0, 7);
+            $this->data['kid'] = $this->getThumbnail();
         }
         return isset($this->data['kid']) ? $this->data['kid'] : null;
     }


### PR DESCRIPTION
Change the method for generating default key IDs (`kid`) from using the first 7 characters of the thumbnail to the full thumbnail.

Fix #234