### PR TITLE
Add check for missing alg header

### DIFF
--- a/src/SimpleJWT/JWT.php
+++ b/src/SimpleJWT/JWT.php
@@ -134,6 +134,7 @@ class JWT extends Token {
         }
 
         // Check signatures
+        if (!isset($headers['alg'])) throw new InvalidTokenException('alg parameter missing', InvalidTokenException::TOKEN_PARSE_ERROR);
         if ($headers['alg'] != $expected_alg) throw new InvalidTokenException('Unexpected algorithm', InvalidTokenException::SIGNATURE_VERIFICATION_ERROR);
         /** @var SignatureAlgorithm $signer */
         $signer = AlgorithmFactory::create($expected_alg);

--- a/tests/JWTTest.php
+++ b/tests/JWTTest.php
@@ -335,6 +335,16 @@ class JWTTest extends TestCase {
         $this->assertTrue($jwt->getClaim('iss'));
     }
 
+    function testMissingAlg() {
+        $this->expectException('SimpleJWT\InvalidTokenException');
+        $this->expectExceptionCode(InvalidTokenException::TOKEN_PARSE_ERROR);
+
+        $set = $this->getPublicKeySet();
+        $token = 'eyJ0eXAiOiAiSldUIn0.eyJpc3MiOiJqb2UiLCJleHAiOjEzMDA4MTkzODB9.lLajjIbnhRpthOPhbJTaxoQ8JHYSAwSUl1Vxc4eQcIU';
+        $jwt = JWT::decode($token, $set, 'HS256');
+        $this->assertTrue($jwt->getClaim('iss'));
+    }
+
     function testInvalidToken() {
         $this->expectException('SimpleJWT\InvalidTokenException');
 


### PR DESCRIPTION
JWT.php already implicitly checks whether the alg header is present by comparing it to $expected_alg.  This commit makes this check explicit and returns a different error code (TOKEN_PARSE_ERROR instead of SIGNATURE_VERIFICATION_ERROR).