### PR TITLE
Fix PHP 8.5 compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ jobs:
           - 8.2
           - 8.3
           - 8.4
+          - 8.5
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/src/SimpleJWT/Keys/KeySet.php
+++ b/src/SimpleJWT/Keys/KeySet.php
@@ -324,7 +324,7 @@ class KeySet {
                     break;
                 }
             }
-            if ($found) $results[$kid] = $key_data;
+            if ($found) $results[$kid ?? ''] = $key_data;
         }
 
         // 3. If zero or one key is found after allowing for mandatory and

--- a/src/SimpleJWT/Util/ASN1/DER.php
+++ b/src/SimpleJWT/Util/ASN1/DER.php
@@ -286,7 +286,7 @@ class DER {
         $data = gmp_export($int);
 
         if (strlen($data) == 0) return "\0";
-        if (ord($data) > 127) return "\0" . $data;
+        if (ord($data[0]) > 127) return "\0" . $data;
         return $data;
     }
 


### PR DESCRIPTION
Issue: https://github.com/kelvinmo/simplejwt/issues/242

Fix deprecations and add PHP 8.5 to the phpunit matrix.

Reproduction of warnings with tests (before fix):
```bash
% ./vendor/bin/phpunit  --display-deprecations
PHPUnit 11.5.50 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.5.5
Configuration: /***/simplejwt/phpunit.xml.dist

...........................DD.......D.......DDD.....DDD........  63 / 113 ( 55%)
.............DDDDDDDDDDD.DDDDDDDDDDD..........DD..              113 / 113 (100%)

Time: 00:00.120, Memory: 12.00 MB

There was 1 PHPUnit test runner warning:

1) No code coverage driver available

--

33 tests triggered 2 PHP deprecations:

1) /***/simplejwt/src/SimpleJWT/Util/ASN1/DER.php:289
ord(): Providing a string that is not one byte long is deprecated. Use ord($str[0]) instead

Triggered by:

* SimpleJWT\Crypt\KeyManagement\RSAESTest::testRSA1_5 (10 times)
  /***/simplejwt/tests/KeyManagement/RSAESTest.php:11
...

2) /***/simplejwt/src/SimpleJWT/Keys/KeySet.php:327
Using null as an array offset is deprecated, use an empty string instead

Triggered by:

* KeySetTest::testPassword (4 times)
  /***/simplejwt/tests/KeySetTest.php:37
...
```

